### PR TITLE
fix: match output file type to selected file type

### DIFF
--- a/assets/js/compression.js
+++ b/assets/js/compression.js
@@ -151,7 +151,7 @@ async function createCompressionOptions(currentProgress, file) {
     onProgress: currentProgress,
     preserveExif: false,
     fileType: selectedFormat || undefined,
-    libURL: "./browser-image-compression.js",
+    libURL: `${location.origin}/assets/vendor/browser-image-compression.js`,
     alwaysKeepResolution: true,
   };
   if (state.controller) {

--- a/assets/js/compression.js
+++ b/assets/js/compression.js
@@ -195,7 +195,7 @@ async function preProcessHeic(file) {
 async function preProcessAvif(file) {
   console.log("Preprocessing AVIF image...");
   const image = await lib.imageCompression(file, config.avifPreProcessOptions);
-  return { preProcessedImage: image, preProcessedNewFileType: "image/jpeg" };
+  return { preProcessedImage: image, preProcessedNewFileType: "image/png" };
 }
 
 async function preProcessIco(file) {

--- a/assets/js/compression.js
+++ b/assets/js/compression.js
@@ -50,18 +50,11 @@ async function compressImageQueue() {
     return;
   }
 
-  // Decode and parase image to validate options.
+  // Decode and parse image to validate options.
   const options = await createCompressionOptions((p) => currentProgress(p, i, file.name), file);
   // Preprocess image when needed (e.g., decoding or precompress image).
-  const { preProcessedImage, preProcessedNewFileType } = await preProcessImage(file);
+  const { preProcessedImage } = await preProcessImage(file);
   const selectedFormat = getCheckedValue(ui.inputs.formatSelect)
-
-  if (preProcessedImage) {
-    options.fileType = preProcessedNewFileType;
-  }
-  if (isPostProcessingRequired(selectedFormat)) {
-    options.fileType = 'image/png';
-  }
 
   // Perform image compression
   lib.imageCompression((preProcessedImage || file), options)

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -70,7 +70,7 @@ app.config = {
     useWebWorker: true,
     preserveExif: false,
     fileType: "image/png",
-    libURL: "./browser-image-compression.js",
+    libURL: `${location.origin}/assets/vendor/browser-image-compression.js`,
     alwaysKeepResolution: true,
   },
   qualityLimit: {
@@ -93,7 +93,7 @@ app.config.avifPreProcessOptions = {
   useWebWorker: true,
   preserveExif: false,
   fileType: "image/png",
-  libURL: "./browser-image-compression.js",
+  libURL: `${location.origin}/assets/vendor/browser-image-compression.js`,
   alwaysKeepResolution: true,
 };
 

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -92,7 +92,7 @@ app.config.avifPreProcessOptions = {
   maxWidthOrHeight: app.config.form.limitDimensions,
   useWebWorker: true,
   preserveExif: false,
-  fileType: "image/jpeg",
+  fileType: "image/png",
   libURL: "./browser-image-compression.js",
   alwaysKeepResolution: true,
 };

--- a/assets/js/utilities.js
+++ b/assets/js/utilities.js
@@ -108,19 +108,17 @@ function isFileExt(file, extension = "") {
 function getFileType(file) {
   let selectedFormat = getCheckedValue(ui.inputs.formatSelect);
   let inputFileType = file.type;
-  let inputFileExtension = "";
+  const inputFileExtension = mimeToExtension(file.type) || "";
   let outputFileExtension = "";
 
   if (selectedFormat && selectedFormat !== "default") {
     // The user-selected format to convert to.
     const extension = mimeToExtension(selectedFormat);
-    inputFileExtension = extension;
     outputFileExtension = extension;
   } else {
     // User has not selected a file format, use the input image's file type.
     selectedFormat = file.type || "png";
     file.type = !file.type && isHeicExt(file) ? "image/heic" : file.type;
-    inputFileExtension = mimeToExtension(file.type) || "";
 
     console.log("inputFileExtension: ", inputFileExtension);
     outputFileExtension = mimeToExtension(defaultConversionMapping(file.type));


### PR DESCRIPTION
This PR resolves #42, the issue of mismatch between the chosen file output type and what is actually generated.

In `compressImageQueue` the compression options are built using `createCompressionOptions`. After building, the options object's `fileType` property is errantly changed to the file type of the preprocessed input image. However, this property is actually used for setting the output file type in the compression library. As a result, the generated blob has the MIME type of the preprocessed image. I've removed the lines editing the `fileType` property so that resulting image is of the selected file type. This also aligns the compression process with the `Default` option within the app's settings, which claims that AVIF files are converted to PNG.

## Notes

- The `preProcessAvif` function may be unneeded as the compression library supports AVIF images as input. The only unique factor I could see for it is setting `maxWidthOrHeight` to `app.config.form.limitDimensions` in `app.config.avifPreProcessOptions`, but that seems to be handled within `createCompressionOptions` already. Regardless, I didn't remove it as there could be something I'm missing there
- The compressed PNG file size for the image provided in the issue ends up being much larger than the original. In testing, this seems to simply be due to the nature of PNG files tending to be larger than JPG. However, I did find occasional success by changing the `maxIteration` compression option to a higher number than the default 10; this was a trade-off with output quality and processing time though, so I haven't included that change in this PR. It may be something to explore in the future though

## Other changes

This PR additionally contains three minor fixes that were tangentially related to the original issue:

1. In `utilities.js`'s `getFileType` the returned `inputFileExtension` property has been correctly set to the input file's actual type
1. AVIF images are preprocessed into PNG as the AV1 format supports transparency
2. The `libURL` property in the built options object from `createCompressionOptions` has been updated with the correct file path