### PR TITLE
fix: preprocess SVG images with missing height and width attributes

### DIFF
--- a/assets/js/compression.js
+++ b/assets/js/compression.js
@@ -179,6 +179,14 @@ async function preProcessImage(file) {
     return await preProcessTiff(file);
   }
 
+  if (file.type === "image/svg+xml") {
+    try {
+      return await preProcessSvg(file);
+    } catch {
+      console.warn('Could not preprocess SVG');
+    }
+  }
+
   return { preProcessedImage: null, preProcessedNewFileType: null };
 }
 
@@ -217,6 +225,51 @@ async function preProcessTiff(file) {
   const rgba = lib.utif.toRGBA8(ifds[0]);
   const parsedTiff = await encodeImageRgbaToBlob(rgba, ifds[0].width, ifds[0].height, "image/png", 1);
   return { preProcessedImage: parsedTiff, preProcessedNewFileType: "image/png" };
+}
+
+/**
+ * Preprocess an SVG image by checking for width and height attributes and
+ * adding them if missing
+ * 
+ * This sidesteps an issue in certain versions of Firefox in which SVG files
+ * without those attributes fail to load within the canvas during processing
+ * 
+ * @param {File} file - The image to process
+ * @returns {Object} - An object containing:
+ *   @property {File} - The preprocessed image
+ *   @property {String} - The MIME type of the preprocessed image
+ */
+async function preProcessSvg(file) {
+  console.info("Preprocessing SVG image…");
+
+  const text = await file.text();
+  const parser = new DOMParser();
+
+  const svgDocument = parser.parseFromString(text, 'image/svg+xml');
+  const svgElement = svgDocument.querySelector('svg');
+  const widthAttribute = svgElement.getAttribute('width');
+  const heightAttribute = svgElement.getAttribute('height');
+
+  if (widthAttribute && heightAttribute) {
+    return { preProcessedImage: file, preProcessedNewFileType: "image/svg+xml" };
+  }
+
+  const viewBox = svgElement.getAttribute('viewBox');
+  const [minX, minY, width, height] = 
+    viewBox?.split(' ').map(part => Number(part)) ?? [ 0, 0, 2_048, 2_048];
+
+  svgElement.setAttribute('width', width - minX);
+  svgElement.setAttribute('height', height - minY);
+
+  const serializer = new XMLSerializer();
+
+  const updatedFile = new File(
+    [ serializer.serializeToString(svgDocument) ],
+    file.name, 
+    { type: 'image/svg+xml' }
+  );
+
+  return { preProcessedImage: updatedFile, preProcessedNewFileType: "image/svg+xml" };
 }
 
 async function postProcessImage(file, selectedFormat, dimensions) {


### PR DESCRIPTION
This PR resolves #35 by detecting SVG files without set `width` and/or `height` attributes. I've added a preprocessing step that calculates dimensions based on the SVG's `viewBox` attribute, if present, or a 2048-pixel square if not.

## Notes

You may want to instead display some sort of error if there is neither `viewBox` nor `width`/`height` set as I think it would be difficult to have a default that actually works for a significant coverage of use cases. For example, if you remove the `viewBox` from the file linked in the issue, the output image's actual content is tiny, with a lot of blank padding space:

<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/0b769320-8c2f-4010-9db9-48d2fdf223bd" />

This would happen e.g. with favicons of small dimensions as well. Conversely, setting the default to a smaller square may instead cut off content unexpectedly. Just about the only benefit of having the default at all would be to avoid displaying an error, which I think is ultimately a better outcome for the user than a conversion that potentially renders the output useless.