### PR TITLE
fix(nginx): avoid duplicate auth_basic on restart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ COPY --from=prepare /usr/share/nginx/html /usr/share/nginx/html
 
 EXPOSE 80
 
-CMD ["/bin/sh", "-c", "if [ -n \"$USERNAME\" ] && [ -n \"$PASSWORD\" ]; then /usr/local/bin/basicauth.sh; fi; nginx -g 'daemon off;'"]
+CMD ["/bin/sh", "-c", "/usr/local/bin/basicauth.sh; nginx -g 'daemon off;'"]

--- a/scripts/basicauth.sh
+++ b/scripts/basicauth.sh
@@ -4,6 +4,9 @@
 if [ -n "$USERNAME" ] && [ -n "$PASSWORD" ]; then
   echo "Setting up basic auth for: $USERNAME"
   htpasswd -bc /etc/nginx/.htpasswd "$USERNAME" "$PASSWORD"
+  # Make this script idempotent across container restarts.
+  # Without this, repeated runs will insert duplicate directives and Nginx will fail to start.
+  sed -i '/auth_basic/d' /etc/nginx/conf.d/default.conf
   sed -i '/location = \/index.html {/a \        auth_basic "Restricted Content";\n        auth_basic_user_file \/etc\/nginx\/.htpasswd;' /etc/nginx/conf.d/default.conf
 else
   rm -f /etc/nginx/.htpasswd


### PR DESCRIPTION
Fixes #49.

Make basic auth setup idempotent across container restarts:
- Always run `basicauth.sh` on startup so it can apply/remove directives based on env.
- In the enabled path, remove any existing `auth_basic*` lines before inserting, preventing duplicate directives and Nginx startup failure.

Repro/verification:
- Start container with USERNAME/PASSWORD
- Restart container; Nginx should keep starting without `auth_basic directive is duplicate`.
