### PR TITLE
chore: add OCI standard labels to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,20 @@ COPY ./config/nginx.conf /etc/nginx/conf.d/default.conf
 
 COPY --from=prepare /usr/share/nginx/html /usr/share/nginx/html
 
+ARG VERSION
+ARG REVISION
+ARG CREATED
+
+LABEL org.opencontainers.image.title="mazanoke" \
+      org.opencontainers.image.description="A self-hosted local image optimizer that runs in your browser" \
+      org.opencontainers.image.url="https://github.com/civilblur/mazanoke" \
+      org.opencontainers.image.source="https://github.com/civilblur/mazanoke" \
+      org.opencontainers.image.vendor="civilblur" \
+      org.opencontainers.image.licenses="GPL-3.0-only" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.created="${CREATED}"
+
 EXPOSE 80
 
 CMD ["/bin/sh", "-c", "/usr/local/bin/basicauth.sh; nginx -g 'daemon off;'"]


### PR DESCRIPTION
## Context

Add [OCI (Open Container Initiative)](https://github.com/opencontainers/image-spec/blob/main/annotations.md) standard labels to the `Dockerfile` for better image metadata and container registry compatibility.

## Type

Improvement — metadata only, no functional changes.

## Labels Added

| Label | Value | Source |
|-------|-------|--------|
| `org.opencontainers.image.title` | `mazanoke` | Static |
| `org.opencontainers.image.description` | `A self-hosted local image optimizer that runs in your browser` | Static |
| `org.opencontainers.image.url` | `https://github.com/civilblur/mazanoke` | Static |
| `org.opencontainers.image.source` | `https://github.com/civilblur/mazanoke` | Static |
| `org.opencontainers.image.vendor` | `civilblur` | Static |
| `org.opencontainers.image.licenses` | `GPL-3.0-only` | Static |
| `org.opencontainers.image.version` | `${VERSION}` | Build arg (optional) |
| `org.opencontainers.image.revision` | `${REVISION}` | Build arg (optional) |
| `org.opencontainers.image.created` | `${CREATED}` | Build arg (optional) |

The three dynamic labels (`version`, `revision`, `created`) use optional build args — the image builds fine without them, they'll simply be empty. When you add CI/CD for automated builds, you can wire them up like so:

```sh
docker build \
  --build-arg VERSION=1.0.0 \
  --build-arg REVISION=$(git rev-parse HEAD) \
  --build-arg CREATED=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
  -t ghcr.io/civilblur/mazanoke:1.0.0 .
```

## Benefits

- **Registry UI**: GHCR displays title, description, license, and source link in its web interface once these labels are present
- **Dependency bot changelogs**: Tools like [Renovate](https://docs.renovatebot.com/modules/datasource/docker/) and Dependabot use `org.opencontainers.image.source` to locate and display changelogs in update PRs — users who self-host mazanoke via Docker will see release notes when updates land
- **Image provenance**: `revision` and `created` allow precise auditing of which source commit produced an image
- **Standardization**: follows OCI best practices for container image metadata

## Changes

- `Dockerfile`: added `ARG VERSION`, `ARG REVISION`, `ARG CREATED` and a `LABEL` block in the final `nginx:alpine` stage, placed after the last `COPY` and before `EXPOSE`

## References

- [OCI Image Spec - Annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)
- [Renovate Docker datasource](https://docs.renovatebot.com/modules/datasource/docker/)
- [Docker - Manage tags and labels](https://docs.docker.com/build/ci/github-actions/manage-tags-labels/)